### PR TITLE
Update EngineIOPolling.cs

### DIFF
--- a/EngineIOSharp/Client/Transport/EngineIOPolling.cs
+++ b/EngineIOSharp/Client/Transport/EngineIOPolling.cs
@@ -97,7 +97,10 @@ namespace EngineIOSharp.Client.Transport
 
         protected override void SendInternal(EngineIOPacket Packet)
         {
-            Request(EngineIOHttpMethod.POST, Packet.Encode(EngineIOTransportType.polling, Option.ForceBase64), (Exception) => OnError("Post error", Exception));
+            if (Packet != null)
+            {
+                Request(EngineIOHttpMethod.POST, Packet.Encode(EngineIOTransportType.polling, Option.ForceBase64), (Exception) => OnError("Post error", Exception));
+            }
         }
 
         private void Request(EngineIOHttpMethod Method = EngineIOHttpMethod.GET, object EncodedPacket = null, Action<Exception> ErrorCallback = null)


### PR DESCRIPTION
See the following screenshot:
![PacketsList](https://user-images.githubusercontent.com/1774797/99377465-e9740180-28ce-11eb-80f5-80bd9eab2e00.png)

I'm not 100% sure how I got to this case, but seems like Packets could contain null items.
I suggest to check if Packet is not null first.

Thanks!