### PR TITLE
CQMAP-708 - Socket Auth

### DIFF
--- a/EngineIOSharp/Common/EngineIOException.cs
+++ b/EngineIOSharp/Common/EngineIOException.cs
@@ -4,9 +4,9 @@ namespace EngineIOSharp.Common
 {
     public class EngineIOException : Exception
     {
-        internal EngineIOException(string message) : base(message) { }
+        public EngineIOException(string message) : base(message) { }
 
-        internal EngineIOException(string message, Exception innerException) : base(message, innerException) { }
+        public EngineIOException(string message, Exception innerException) : base(message, innerException) { }
 
         public override bool Equals(object obj)
         {


### PR DESCRIPTION
Made EngineIOException public so that `AllowHttpRequest` can be used on the SyncServer